### PR TITLE
Grist torrent fixes

### DIFF
--- a/src/main/java/com/mraof/minestuck/client/gui/computer/GristTorrentGui.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/computer/GristTorrentGui.java
@@ -6,8 +6,6 @@ import com.mraof.minestuck.alchemy.TorrentSession;
 import com.mraof.minestuck.alchemy.TorrentSession.LimitedCache;
 import com.mraof.minestuck.api.alchemy.GristAmount;
 import com.mraof.minestuck.api.alchemy.GristSet;
-import com.mraof.minestuck.api.alchemy.GristType;
-import com.mraof.minestuck.api.alchemy.GristTypes;
 import com.mraof.minestuck.blockentity.ComputerBlockEntity;
 import com.mraof.minestuck.client.gui.MSScreenFactories;
 import com.mraof.minestuck.client.gui.computer.TorrentWidgets.*;
@@ -55,8 +53,6 @@ public final class GristTorrentGui extends Screen implements ProgramGui<ProgramT
 	private final List<GutterBar> gutterBars = new ArrayList<>();
 	private StatsContainer statsContainer;
 	
-	private List<GristType> allGristTypes;
-	
 	private int updateTick = 0;
 	
 	public GristTorrentGui()
@@ -75,8 +71,6 @@ public final class GristTorrentGui extends Screen implements ProgramGui<ProgramT
 		visibleTorrentData.clear();
 		ClientPlayerData.getVisibleTorrentData().forEach(((torrentSession, limitedCache) ->
 				visibleTorrentData.put(torrentSession.getSeeder(), Pair.of(torrentSession, limitedCache))));
-		
-		this.allGristTypes = GristTypes.REGISTRY.stream().toList();
 		
 		if(minecraft == null || minecraft.player == null)
 			return;
@@ -210,7 +204,7 @@ public final class GristTorrentGui extends Screen implements ProgramGui<ProgramT
 		int combinedXOffset = xOffset + 5 + ((GristEntry.WIDTH + 2) * torrentXOffset);
 		
 		//TODO because this is being reset, the tooltip is flashing and the scroll returns to 0 preventing it from moving
-		TorrentContainer torrentContainer = new TorrentContainer(combinedXOffset, gristWidgetsYOffset, font, torrentSession.getSeeder(), allGristTypes);
+		TorrentContainer torrentContainer = new TorrentContainer(combinedXOffset, gristWidgetsYOffset, font, torrentSession.getSeeder());
 		torrentContainer.refreshEntries(torrentSession, cache);
 		torrentContainers.add(torrentContainer);
 		addRenderableWidget(torrentContainer);

--- a/src/main/java/com/mraof/minestuck/client/gui/computer/TorrentWidgets.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/computer/TorrentWidgets.java
@@ -72,7 +72,7 @@ public class TorrentWidgets
 		public static final int GRIST_COUNT_X = GRIST_ICON_X + 13;
 		public static final float BAR_WIDTH = 20F;
 		
-		public TorrentSession torrentSession;
+		private TorrentSession torrentSession;
 		public LimitedCache cache;
 		public final GristType gristType;
 		public long gristAmount;
@@ -165,7 +165,7 @@ public class TorrentWidgets
 			if(isOwner)
 				PacketDistributor.sendToServer(new TorrentPackets.ModifySeeding(gristType, isActive));
 			else
-				PacketDistributor.sendToServer(new TorrentPackets.ModifyLeeching(torrentSession, gristType, isActive));
+				PacketDistributor.sendToServer(new TorrentPackets.ModifyLeeching(torrentSession.getSeeder(), gristType, isActive));
 		}
 		
 		@Override

--- a/src/main/java/com/mraof/minestuck/client/gui/computer/TorrentWidgets.java
+++ b/src/main/java/com/mraof/minestuck/client/gui/computer/TorrentWidgets.java
@@ -182,18 +182,15 @@ public class TorrentWidgets
 		public final IdentifierHandler.UUIDIdentifier player;
 		private final Font font;
 		
-		private final List<GristType> allGristTypes;
-		
-		public TorrentContainer(int pX, int pY, Font font, IdentifierHandler.UUIDIdentifier player, List<GristType> allGristTypes)
+		public TorrentContainer(int pX, int pY, Font font, IdentifierHandler.UUIDIdentifier player)
 		{
 			super(pX, pY, WIDTH, HEIGHT);
 			
 			this.player = player;
 			this.font = font;
-			this.allGristTypes = allGristTypes;
 			
 			int yOffset = 1; //this is 1 because there needs to be room to render the name of the torrent's seeder
-			for(GristType type : allGristTypes)
+			for(GristType type : GristTypes.REGISTRY)
 			{
 				GristEntry gristEntry = new GristEntry(pX, pY + ((GristEntry.HEIGHT + 1) * yOffset), type);
 				if(this.children().size() < visibleEntryCount())
@@ -251,7 +248,7 @@ public class TorrentWidgets
 		@Override
 		public int getMaxScroll()
 		{
-			return Math.max(0, allGristTypes.size() - visibleEntryCount());
+			return Math.max(0, this.children().size() - visibleEntryCount());
 		}
 		
 		@Override

--- a/src/main/java/com/mraof/minestuck/network/TorrentPackets.java
+++ b/src/main/java/com/mraof/minestuck/network/TorrentPackets.java
@@ -19,10 +19,10 @@ import java.util.Map;
 
 public class TorrentPackets
 {
-	public record UpdateClient(Map<TorrentSession, TorrentSession.LimitedCache> data) implements MSPacket.PlayToClient
+	public record UpdateClient(Map<Integer, TorrentSession.TorrentClientData> data) implements MSPacket.PlayToClient
 	{
 		public static final Type<UpdateClient> ID = new Type<>(Minestuck.id("torrent_update_client"));
-		private static final StreamCodec<RegistryFriendlyByteBuf, Map<TorrentSession, TorrentSession.LimitedCache>> MAP_STREAM_CODEC = ByteBufCodecs.map(HashMap::new, TorrentSession.STREAM_CODEC, TorrentSession.LimitedCache.STREAM_CODEC);
+		private static final StreamCodec<RegistryFriendlyByteBuf, Map<Integer, TorrentSession.TorrentClientData>> MAP_STREAM_CODEC = ByteBufCodecs.map(HashMap::new, ByteBufCodecs.INT, TorrentSession.TorrentClientData.STREAM_CODEC);
 		public static final StreamCodec<RegistryFriendlyByteBuf, UpdateClient> STREAM_CODEC = MAP_STREAM_CODEC.map(UpdateClient::new, UpdateClient::data);
 		
 		@Override
@@ -61,17 +61,17 @@ public class TorrentPackets
 			MinecraftServer server = player.server;
 			MSExtraData data = MSExtraData.get(server);
 			
-			data.updateTorrentSeeding((IdentifierHandler.UUIDIdentifier) IdentifierHandler.encode(player), gristType, isSeeding);
+			data.updateTorrentSeeding(IdentifierHandler.encode(player), gristType, isSeeding);
 		}
 	}
 	
-	public record ModifyLeeching(IdentifierHandler.UUIDIdentifier target, GristType gristType,
+	public record ModifyLeeching(Integer targetId, GristType gristType,
 								 boolean isLeeching) implements MSPacket.PlayToServer
 	{
 		public static final Type<ModifyLeeching> ID = new Type<>(Minestuck.id("torrent_modify_leeching"));
 		public static final StreamCodec<RegistryFriendlyByteBuf, ModifyLeeching> STREAM_CODEC = StreamCodec.composite(
-				IdentifierHandler.UUIDIdentifier.STREAM_CODEC,
-				ModifyLeeching::target,
+				ByteBufCodecs.INT,
+				ModifyLeeching::targetId,
 				GristType.STREAM_CODEC,
 				ModifyLeeching::gristType,
 				ByteBufCodecs.BOOL,
@@ -91,7 +91,7 @@ public class TorrentPackets
 			MinecraftServer server = player.server;
 			MSExtraData data = MSExtraData.get(server);
 			
-			data.updateTorrentLeeching(target, (IdentifierHandler.UUIDIdentifier) IdentifierHandler.encode(player), gristType, isLeeching);
+			data.updateTorrentLeeching(IdentifierHandler.getById(targetId), IdentifierHandler.encode(player), gristType, isLeeching);
 		}
 	}
 }

--- a/src/main/java/com/mraof/minestuck/network/TorrentPackets.java
+++ b/src/main/java/com/mraof/minestuck/network/TorrentPackets.java
@@ -65,13 +65,13 @@ public class TorrentPackets
 		}
 	}
 	
-	public record ModifyLeeching(TorrentSession torrentSession, GristType gristType,
+	public record ModifyLeeching(IdentifierHandler.UUIDIdentifier target, GristType gristType,
 								 boolean isLeeching) implements MSPacket.PlayToServer
 	{
 		public static final Type<ModifyLeeching> ID = new Type<>(Minestuck.id("torrent_modify_leeching"));
 		public static final StreamCodec<RegistryFriendlyByteBuf, ModifyLeeching> STREAM_CODEC = StreamCodec.composite(
-				TorrentSession.STREAM_CODEC,
-				ModifyLeeching::torrentSession,
+				IdentifierHandler.UUIDIdentifier.STREAM_CODEC,
+				ModifyLeeching::target,
 				GristType.STREAM_CODEC,
 				ModifyLeeching::gristType,
 				ByteBufCodecs.BOOL,
@@ -91,7 +91,7 @@ public class TorrentPackets
 			MinecraftServer server = player.server;
 			MSExtraData data = MSExtraData.get(server);
 			
-			data.updateTorrentLeeching(torrentSession, (IdentifierHandler.UUIDIdentifier) IdentifierHandler.encode(player), gristType, isLeeching);
+			data.updateTorrentLeeching(target, (IdentifierHandler.UUIDIdentifier) IdentifierHandler.encode(player), gristType, isLeeching);
 		}
 	}
 }

--- a/src/main/java/com/mraof/minestuck/player/ClientPlayerData.java
+++ b/src/main/java/com/mraof/minestuck/player/ClientPlayerData.java
@@ -44,7 +44,7 @@ public final class ClientPlayerData
 	private static GristSet gutterGrist;
 	private static long gutterRemainingCapacity;
 	private static long targetCacheLimit;
-	private static Map<TorrentSession, TorrentSession.LimitedCache> visibleTorrentData = new HashMap<>();
+	private static Map<Integer, TorrentSession.TorrentClientData> visibleTorrentData = new HashMap<>();
 	private static int playerColor;
 	private static boolean displaySelectionGui;
 	private static boolean dataCheckerAccess;
@@ -120,7 +120,7 @@ public final class ClientPlayerData
 		return gutterRemainingCapacity;
 	}
 	
-	public static Map<TorrentSession, TorrentSession.LimitedCache> getVisibleTorrentData()
+	public static Map<Integer, TorrentSession.TorrentClientData> getVisibleTorrentData()
 	{
 		return visibleTorrentData;
 	}

--- a/src/main/java/com/mraof/minestuck/player/IdentifierHandler.java
+++ b/src/main/java/com/mraof/minestuck/player/IdentifierHandler.java
@@ -1,14 +1,8 @@
 package com.mraof.minestuck.player;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.core.UUIDUtil;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
-import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.codec.ByteBufCodecs;
-import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.PlayerList;
@@ -159,24 +153,11 @@ public class IdentifierHandler
 		fakePlayerIndex = 0;
 	}
 	
-	public static class UUIDIdentifier extends PlayerIdentifier
+	private static class UUIDIdentifier extends PlayerIdentifier
 	{
-		public static final Codec<UUIDIdentifier> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-				Codec.INT.fieldOf("id").forGetter(UUIDIdentifier::getId),
-				Codec.STRING.xmap(UUID::fromString, UUID::toString).fieldOf("uuid").forGetter(UUIDIdentifier::getUUID)
-		).apply(instance, UUIDIdentifier::new));
-		public static final StreamCodec<RegistryFriendlyByteBuf, UUIDIdentifier> STREAM_CODEC = StreamCodec.composite(
-				ByteBufCodecs.INT,
-				UUIDIdentifier::getId,
-				UUIDUtil.STREAM_CODEC,
-				UUIDIdentifier::getUUID,
-				UUIDIdentifier::new
-		);
-		
 		private final UUID uuid;
 		
-		//TODO make this constructor private again. Exposed for testing
-		public UUIDIdentifier(int id, UUID uuid)
+		private UUIDIdentifier(int id, UUID uuid)
 		{
 			super(id);
 			this.uuid = uuid;

--- a/src/main/java/com/mraof/minestuck/world/storage/MSExtraData.java
+++ b/src/main/java/com/mraof/minestuck/world/storage/MSExtraData.java
@@ -6,8 +6,8 @@ import com.mraof.minestuck.alchemy.TorrentSession;
 import com.mraof.minestuck.api.alchemy.GristType;
 import com.mraof.minestuck.computer.editmode.EditData;
 import com.mraof.minestuck.entry.PostEntryTask;
-import net.minecraft.core.HolderLookup;
 import com.mraof.minestuck.player.IdentifierHandler;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
@@ -259,13 +259,13 @@ public class MSExtraData extends SavedData
 		setDirty(); //TODO should this be set to dirty even if no information is changed?
 	}
 	
-	public void updateTorrentLeeching(TorrentSession torrentSessionIn, IdentifierHandler.UUIDIdentifier playerID, GristType gristType, boolean isLeeching)
+	public void updateTorrentLeeching(IdentifierHandler.UUIDIdentifier target, IdentifierHandler.UUIDIdentifier playerID, GristType gristType, boolean isLeeching)
 	{
 		for(int i = 0; i < torrentSessions.size(); i++)
 		{
 			TorrentSession torrentSession = torrentSessions.get(i);
 			
-			if(torrentSession.sameOwner(torrentSessionIn))
+			if(torrentSession.sameOwner(target))
 			{
 				List<TorrentSession.Leech> leeching = new ArrayList<>(torrentSession.getLeeching());
 				


### PR DESCRIPTION
Fixes some part of the implementation, hopefully making it easier to continue working with it.

- The TorrentContainer and StatsContainer widgets now take more responsibility over their sub-widgets.
- The TorrentContainers are now recreated much less (though it could still be improved even further in some aspects)
- Player id is now used as map key instead of TorrentSession.
- Player identifiers are now used more correctly, avoiding some weird issues where the integer id persists when it is not supposed to, and the full id is no longer transferred to and used client-side.